### PR TITLE
Add ParseString() method to nodeutility class

### DIFF
--- a/Code/Classes/classes.ps1
+++ b/Code/Classes/classes.ps1
@@ -9,6 +9,13 @@ class nodeutility {
         return $x
     }
 
+    [node[]] static ParseString ([string[]]$String) {
+        $ParsedFile     = [Parser]::ParseInput($String, [ref]$null, [ref]$Null)
+        $RawAstDocument = $ParsedFile.FindAll({$args[0] -is [Ast]}, $false)
+        $x=$RawAstDocument | ForEach-Object{if ( $null -eq $_.parent.parent.parent ) { $t = [nodeutility]::SetNode($_); if ( $null -ne  $t) { $t} } }
+        return $x
+    }
+
     [node] static SetNode ([object]$e) {
         $node = $null
         Switch ( $e ) {

--- a/Tests/tests.ps1
+++ b/Tests/tests.ps1
@@ -9,6 +9,13 @@ class nodeutility {
         return $x
     }
 
+    [node[]] static ParseString ([string[]]$String) {
+        $ParsedFile     = [Parser]::ParseInput($String, [ref]$null, [ref]$Null)
+        $RawAstDocument = $ParsedFile.FindAll({$args[0] -is [Ast]}, $false)
+        $x=$RawAstDocument | ForEach-Object{if ( $null -eq $_.parent.parent.parent ) { $t = [nodeutility]::SetNode($_); if ( $null -ne  $t) { $t} } }
+        return $x
+    }
+
     [node] static SetNode ([object]$e) {
         $node = $null
         Switch ( $e ) {
@@ -419,4 +426,4 @@ Class DoWhileNode : node {
 
 
 ## Exampple
-$x=[nodeutility]::ParseFile("C:\users\lx\gitperso\PSScriptDiagram\sample.ps1")
+$x=[nodeutility]::ParseFile("$PWD\Tests\scripts_samples\sample.ps1")


### PR DESCRIPTION
This method can parse a string code like a script : 
PS > $String = @'  
if ($x -eq 'toto') {  
foreach ($u in $x )  
{"titi"}  
}  
'@  

PS > [nodeutility]::ParseInput($string)  
Type        : If  
Statement   : If ( $x -eq 'toto' )  
Description :  
Children    : {ForeachNode}  
Parent      :  
Depth       : 1  
File        :  
